### PR TITLE
Cron testing.

### DIFF
--- a/.github/workflows/cron-testing.yml
+++ b/.github/workflows/cron-testing.yml
@@ -6,6 +6,8 @@ name: Cron testing
 
 on:
   schedule:
+    # Please set the start time (UTC time zone).
+    # https://docs.github.com/cn/actions/using-workflows/events-that-trigger-workflows#schedule
     - cron:  '0 0 * * *'
 
 jobs:

--- a/.github/workflows/cron-testing.yml
+++ b/.github/workflows/cron-testing.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     # Please set the start time (UTC time zone).
     # https://docs.github.com/cn/actions/using-workflows/events-that-trigger-workflows#schedule
-    - cron:  '0 0 * * *'
+    - cron: '0 12 * * MON-FRI'
 
 jobs:
   test:

--- a/.github/workflows/cron-testing.yml
+++ b/.github/workflows/cron-testing.yml
@@ -1,0 +1,54 @@
+# Schedule testing task
+# https://docs.github.com/cn/actions/using-workflows/events-that-trigger-workflows#schedule
+# Please set SENDER_MNEMONIC, SLACK_WEBHOOK_URL in github secrets.
+
+name: Cron testing
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+            npm install
+            npm ci
+
+      - name: Run test
+        env:
+          SENDER_MNEMONIC: ${{ secrets.SENDER_MNEMONIC }}
+        run: |
+          npm run test:all
+
+  report-failure:
+    name: Report failure status
+    needs: [test]
+    if: failure()
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check workflow status
+        id: check-workflow-status
+        uses: martialonline/workflow-status@v2
+
+      - name: Report to slack
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ steps.check-workflow-status.outputs.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Events that trigger workflows - schedule
https://docs.github.com/cn/actions/using-workflows/events-that-trigger-workflows#schedule

Github has the disadvantage of this feature, it does not guarantee on-time startup.
https://upptime.js.org/blog/2021/01/22/github-actions-schedule-not-working/

_It's added to a queue and run whenever GitHub has a machine available, sometimes this is every 7 minutes, sometimes every 15 minutes._

But I think it's good enough for our testing. And it's simple and free.

**Please set `SENDER_MNEMONIC`, `SLACK_WEBHOOK_URL` in github secrets.**

This is my cron testing example.
<img width="956" alt="image" src="https://user-images.githubusercontent.com/16951509/170240278-ee8ba7c3-4e77-4311-8de0-9f3f0f87ffc7.png">

