### PR TITLE
Fix test timeout issue

### DIFF
--- a/test/functional/cancel.test.ts
+++ b/test/functional/cancel.test.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { sendExtrinsic, getNativeTransferExtrinsicParams, getNotifyExtrinsicParams, cancelTaskAndVerify, SECTION_NAME, checkBalance, getContext, scheduleNotifyTaskAndVerify, scheduleNativeTransferAndVerify } from './helpFn';
 
 beforeEach(() => {
-  jest.setTimeout(180000);
+  jest.setTimeout(540000);
 });
 
 test('Cancel failed with incorrect format taskID', async () => {

--- a/test/functional/notify.test.ts
+++ b/test/functional/notify.test.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { SECTION_NAME, sendExtrinsic, getNotifyExtrinsicParams, cancelTaskAndVerify, scheduleNotifyTaskAndVerify, getContext, checkBalance } from './helpFn';
 
 beforeEach(() => {
-  jest.setTimeout(120000);
+  jest.setTimeout(540000);
 });
 
 test('scheduler.buildScheduleNotifyExtrinsic works', async () => {

--- a/test/functional/transefer.test.ts
+++ b/test/functional/transefer.test.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { sendExtrinsic, SECTION_NAME, getNativeTransferExtrinsicParams, getContext, cancelTaskAndVerify, checkBalance, scheduleNativeTransferAndVerify } from './helpFn';
 
 beforeEach(() => {
-  jest.setTimeout(120000);
+  jest.setTimeout(540000);
 });
 
 test('scheduler.buildScheduleNativeTransferExtrinsic works', async () => {


### PR DESCRIPTION
I read the code of WsProvider and found that it is able to automatically reconnect when disconnected.

https://github.com/polkadot-js/api/blob/967f5e980acbb9863a0f6462f3df00eb15242b6e/packages/rpc-provider/src/ws/index.ts#L572

And I did a lot of tests to verify.

For example:
https://github.com/imstar15/OAK-JS-SDK/actions/runs/2729728742

As long as we adjust jest's timeout to be longer, we can avoid the problem of test failure.